### PR TITLE
client secret no longer base64 encoded by default

### DIFF
--- a/00-Starter-Seed/src/main/webapp/WEB-INF/web.xml
+++ b/00-Starter-Seed/src/main/webapp/WEB-INF/web.xml
@@ -101,6 +101,12 @@
         <param-value>{CLIENT_SECRET}</param-value>
     </context-param>
 
+    <!-- Auth0 secrets are not base64 encoded by default so leave as false -->
+    <context-param>
+        <param-name>auth0.base64_encoded_secret</param-name>
+        <param-value>false</param-value>
+    </context-param>
+
     <!--only required when using RS256 - obtain cert.pem from Auth0 Dashboard for your Tenant-->
     <context-param>
         <param-name>auth0.public_key_path</param-name>

--- a/01-Login/src/main/webapp/WEB-INF/web.xml
+++ b/01-Login/src/main/webapp/WEB-INF/web.xml
@@ -101,6 +101,12 @@
         <param-value>{CLIENT_SECRET}</param-value>
     </context-param>
 
+    <!-- Auth0 secrets are not base64 encoded by default so leave as false -->
+    <context-param>
+        <param-name>auth0.base64_encoded_secret</param-name>
+        <param-value>false</param-value>
+    </context-param>
+
     <!--only required when using RS256 - obtain cert.pem from Auth0 Dashboard for your Tenant-->
     <context-param>
         <param-name>auth0.public_key_path</param-name>

--- a/09-MFA/src/main/webapp/WEB-INF/web.xml
+++ b/09-MFA/src/main/webapp/WEB-INF/web.xml
@@ -101,6 +101,12 @@
         <param-value>{CLIENT_SECRET}</param-value>
     </context-param>
 
+     <!-- Auth0 secrets are not base64 encoded by default so leave as false -->
+    <context-param>
+        <param-name>auth0.base64_encoded_secret</param-name>
+        <param-value>false</param-value>
+    </context-param>
+
     <!--only required when using RS256 - obtain cert.pem from Auth0 Dashboard for your Tenant-->
     <context-param>
         <param-name>auth0.public_key_path</param-name>


### PR DESCRIPTION
Only merge this PR when Auth0 officially switches to client secrets that are not base64 encoded.