### PR TITLE
update to use Java 8 as required by latest mvc-auth-commons version

### DIFF
--- a/01-Login/Dockerfile
+++ b/01-Login/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:4.2-jdk7-alpine
+FROM gradle:4.2-jdk8
 
 WORKDIR /home/gradle
 ADD . /home/gradle

--- a/01-Login/build.gradle
+++ b/01-Login/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'war'
 apply from: 'https://raw.githubusercontent.com/akhikhl/gretty/master/pluginScripts/gretty.plugin'
 
 compileJava {
-    sourceCompatibility '1.7'
-    targetCompatibility '1.7'
+    sourceCompatibility '1.8'
+    targetCompatibility '1.8'
 }
 
 gretty {
@@ -24,5 +24,4 @@ dependencies {
     compile 'com.auth0:mvc-auth-commons:1.+'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     runtime 'javax.servlet:jstl:1.2'
-    testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
Latest `mvc-auth-commons` uses `org.apache.commons:commons-lang3:3.9`, which requires Java 8. This PR updates this sample to target Java 8 to prevent the `unsupported major.minor version 52.0` error, without freezing this sample at an earlier version of `mvc-auth-commons`.